### PR TITLE
add `conf.execute_log_text_path` to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Create 'rrrspec-server-config.rb'
         host: 'localhost'
       }
       conf.json_cache_path = '/vol/rrrspec-api-cache'
-      conf.execute_log_text_path = "/vol/rrrspec-log-texts"
+      conf.execute_log_text_path = '/vol/rrrspec-log-texts'
     end
 
     RRRSpec.configure(:worker) do |conf|

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Create 'rrrspec-server-config.rb'
         host: 'localhost'
       }
       conf.json_cache_path = '/vol/rrrspec-api-cache'
+      conf.execute_log_text_path = "./rrrspec-server.log"
     end
 
     RRRSpec.configure(:worker) do |conf|

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Create 'rrrspec-server-config.rb'
         host: 'localhost'
       }
       conf.json_cache_path = '/vol/rrrspec-api-cache'
-      conf.execute_log_text_path = "./rrrspec-server.log"
+      conf.execute_log_text_path = "/vol/rrrspec-log-texts"
     end
 
     RRRSpec.configure(:worker) do |conf|


### PR DESCRIPTION
The server won't run without this option set, so it would be nice to have in the example.
